### PR TITLE
Add "/usr/games" to list of package locations.

### DIFF
--- a/assettocorsa-linux-setup.sh
+++ b/assettocorsa-linux-setup.sh
@@ -24,6 +24,7 @@ fi
 
 installed_packages=($(ls /bin))
 installed_packages+=($(ls /usr/bin))
+installed_packages+=($(ls /usr/games 2> /dev/null))
 installed_flatpaks=($(flatpak list --columns=application))
 req_packages=("steam" "wget2" "unzip")
 req_flatpaks=("protontricks")


### PR DESCRIPTION
Installing Steam through Pop!_Shop on Pop!_OS puts it in /usr/games. Added the redirect so not to print an error message if the directory doesn't exist.