### PR TITLE
Change wget2 to wget as required package.

### DIFF
--- a/assettocorsa-linux-setup.sh
+++ b/assettocorsa-linux-setup.sh
@@ -25,7 +25,7 @@ fi
 installed_packages=($(ls /bin))
 installed_packages+=($(ls /usr/bin))
 installed_flatpaks=($(flatpak list --columns=application))
-req_packages=("steam" "wget2" "unzip")
+req_packages=("steam" "wget" "unzip")
 req_flatpaks=("protontricks")
 
 # Checking if Steam is installed through Flatpak


### PR DESCRIPTION
This script doesn't use any feautres of wget2 thats incompatable with wget.

And with the wildcards in the required package check, both 'wget' and 'wget2' will match with this change.