### PR TITLE
Correctly set the STEAMAPPS variable when entering the steamapps path manually.

### DIFF
--- a/assettocorsa-linux-setup.sh
+++ b/assettocorsa-linux-setup.sh
@@ -78,10 +78,14 @@ echo "Dependencies found."
 
 # Defining functions
 function enter_manually () {
-  Ask "Enter path to ${bold}steamapps/common/assettocorsa${normal} manually?" && read ac_dir
-  if [[ $ac_dir == "" ]]; then
+  echo "Enter the path to the ${bold}steamapps${normal} directory assettocorsa is installed in: " && read steamapps
+  if [[ $steamapps == "" ]]; then
     exit 1
-  elif [ -d $ac_dir ] && [[ $(echo $ac_dir | sed -e 's/.*assettocorsa/assettocorsa/') == "assettocorsa" ]]; then
+  fi
+
+  ac_dir="${steamapps}/common/assettocorsa"
+  STEAMAPPS=$steamapps
+  if [ -d $ac_dir ] && [[ $(echo $ac_dir | sed -e 's/.*assettocorsa/assettocorsa/') == "assettocorsa" ]]; then
     echo "Directory valid. Proceeding."
   else
     echo "Invalid directory. Exiting."


### PR DESCRIPTION
If assettocorsa is installed at a non-default path, the STEAMAPPS variable never gets set and the install script will always fail after the ProtonGE step.

This one changes the user flow a bit by removing the "Ask" function call before requiring typing the path. It also asks for the steamapps path, rather than the assettocorsa install path.

You could still ask for the assettocorsa directory, and then remove the trailing "common/assettocorsa" from the path to get the correct STEAMAPPS path. Let me know what direction you'd like to take it.