### PR TITLE
Add Simhub installation and race launching from links.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A shell script based on [this](https://steamcommunity.com/sharedfiles/filedetail
 
 - Installs [Proton-GE](https://github.com/GloriousEggroll/proton-ge-custom)
 - Installs [Content Manager](https://assettocorsa.club/content-manager.html) and everything else required for it to work
-- Adds Content Manager to mimeapps.list (allows opening `acmanager://` race invite links)
+- Adds an `acmanager://` URI handler for opening race invite links in Content Manager
 - Installs [Custom Shaders Patch (CSP)](https://acstuff.club/patch/) and everything else required for it to work
 - Installs [DXVK](https://github.com/doitsujin/dxvk)
 - Optionally installs [SimHub](https://github.com/SHWotever/SimHub) into Assetto Corsa's Proton prefix
@@ -74,5 +74,6 @@ After the install finishes:
 
 ### Other
 
+- Race invite links using the `acmanager://` scheme should open through Content Manager. When Content Manager is closed, the handler starts it through Steam. When Content Manager is already open, the handler tries to pass the invite directly to Content Manager inside the existing Proton prefix. If a specific invite source still fails, copy the `ip` and `httpPort` values from the link and search for `ip:httpPort` in Content Manager's server browser.
 - To fix the font in Content Manager (it's Times New Roman by default) run `protontricks 244210 regedit` in the terminal. Then, in the opened window, go to `HKEY_CURRENT_USER\Software\Wine\Fonts\Replacements` and rename the `Replacements` key to `Replacements Backup`.
 - SimHub is installed into Assetto Corsa's compatibility prefix and should be started after Assetto Corsa. Starting SimHub first and then launching Assetto Corsa from SimHub can prevent Steam from launching the game correctly.

--- a/README.md
+++ b/README.md
@@ -1,36 +1,78 @@
 # Assetto Corsa Linux Setup
+
 A shell script based on [this](https://steamcommunity.com/sharedfiles/filedetails/?id=2828364666) guide. Works on most modern systems.
 
 ## What it does
+
 - Installs [Proton-GE](https://github.com/GloriousEggroll/proton-ge-custom)
 - Installs [Content Manager](https://assettocorsa.club/content-manager.html) and everything else required for it to work
 - Adds Content Manager to mimeapps.list (allows opening `acmanager://` race invite links)
 - Installs [Custom Shaders Patch (CSP)](https://acstuff.club/patch/) and everything else required for it to work
 - Installs [DXVK](https://github.com/doitsujin/dxvk)
+- Optionally installs [SimHub](https://github.com/SHWotever/SimHub) into Assetto Corsa's Proton prefix
+- Optionally installs the Apple CarPlay SimHub dashboard addon when the required addon zip files are provided
 
 After running the script you should be able to launch Assetto Corsa from Steam with no issues (it will launch Content Manager). The original launcher is preserved as `AssettoCorsa_original.exe`.
 
 ## Instructions
+
 1. Download Assetto Corsa on Steam.
 2. Inside the terminal, run
+
   ```
   curl -Os https://raw.githubusercontent.com/sihawido/assettocorsa-linux-setup/main/assettocorsa-linux-setup.sh && bash assettocorsa-linux-setup.sh
   ```
+
 > [!WARNING]
 > Always be careful when running scripts from the internet.
-3. Follow every step in the console (y - stands for yes, n - stands for no).
+1. Follow every step in the console (y - stands for yes, n - stands for no).
+
 > [!NOTE]
 > If you encounter an error with protontricks, something like `SyntaxError: Invalid file magic number`, use [pipx to install a more up-to-date version](https://github.com/Matoking/protontricks?tab=readme-ov-file#pipx) ([#33](https://github.com/sihawido/assettocorsa-linux-setup/issues/33)).
-4. Launch Assetto Corsa from Steam (it might take a while on the first run, be patient).
-5. In Content Manager set the Assetto Corsa root folder to `Z:\path\to\Steam\steamapps\common\assettocorsa`.
-6. In Content Manager, go to `Settings -> Content Manager -> Appearace` and check "Disable windows transparency" (fixes the full-black tooltips, pop-ups and dialogues).
-7. Enjoy!
+1. Launch Assetto Corsa from Steam (it might take a while on the first run, be patient).
+2. In Content Manager set the Assetto Corsa root folder to `Z:\path\to\Steam\steamapps\common\assettocorsa`.
+3. In Content Manager, go to `Settings -> Content Manager -> Appearace` and check "Disable windows transparency" (fixes the full-black tooltips, pop-ups and dialogues).
+4. If you installed SimHub, start Assetto Corsa first from Steam/Content Manager, then start SimHub:
+
+  ```
+  ~/.local/bin/simhub
+  ```
+1. Enjoy!
+
+## Installing the Apple CarPlay SimHub addon
+
+The CarPlay addon install is offered only after SimHub is installed into Assetto Corsa's Proton prefix. If you skipped SimHub on the first run, run the setup script again and choose the SimHub install step first.
+
+Before accepting the CarPlay addon prompt, download the addon files and put both zip files in the same folder:
+
+- `Apple-CarPlay.zip`
+- `SimHubUDPConnector.zip`
+
+When the script asks for the folder containing those files, enter that folder path. The default path is:
+
+```
+~/Downloads/Assetto Downloads/Carplay
+```
+
+The script installs the SimHub dashboard, the UDP connector plugin and Assetto Corsa app, the CarPlay torque extension, required font, and Content Manager preview presets when Content Manager's config folder already exists.
+
+After the install finishes:
+
+1. Start Assetto Corsa from Steam/Content Manager first, then start SimHub with `~/.local/bin/simhub`.
+2. In AC/CSP, enable the SimHub UDPConnector extension and activate `TorquePowerExtensionMy`.
+3. In SimHub, enable Media Information and set the dashboard's simulated keys to match your Assetto Corsa controls.
+4. In Content Manager, generate previews twice using `preview_light` and `preview_nolight`.
 
 ## Notes
+
 ### Fixing crashes
+
 - Having Assetto Corsa installed on a NTFS partition can cause many issues, including crashes. The only solution is to install Assetto Corsa on a partition with a proper linux filesystem (i.e. ext4 or btrfs).
 - Creating a Start Menu Shortcut for Content Manager might cause it to crash. This script will check if it exists and ask whether you want to delete it.
 - Opening the 'Live' tab in earlier versions of Content Manager could cause a crash. After that you might have a hard time since Content Manager will open that tab on start-up. You can delete the Content Manager configuration folder at `/path/to/Steam/steamapps/compatdata/244210/pfx/drive_c/users/steamuser/AppData/Local/AcTools Content Manager` to resolve the crash, but that will also get rid of any settings you might have saved, be sure to back it up.
 - Content Manager can sometimes crash while loading a server's info, there is an [open pull request to fix it](https://github.com/gro-ove/actools/pull/114), but it's unclear whether it will ever be merged.
+
 ### Other
+
 - To fix the font in Content Manager (it's Times New Roman by default) run `protontricks 244210 regedit` in the terminal. Then, in the opened window, go to `HKEY_CURRENT_USER\Software\Wine\Fonts\Replacements` and rename the `Replacements` key to `Replacements Backup`.
+- SimHub is installed into Assetto Corsa's compatibility prefix and should be started after Assetto Corsa. Starting SimHub first and then launching Assetto Corsa from SimHub can prevent Steam from launching the game correctly.

--- a/assettocorsa-linux-setup.sh
+++ b/assettocorsa-linux-setup.sh
@@ -22,6 +22,7 @@ fi
 # Versions
 GE_version="9-20"
 CSP_version="0.2.11"
+SIMHUB_VERSION="9.11.13"
 
 # Defining text styles for readablity
 bold=$(echo -e "\033[1m")
@@ -34,8 +35,8 @@ function ask {
   while true; do
     read -rp "$* [y/n]: " yn
     case $yn in
-      [Yy]*) return 0 ;;
-      [Nn]*) return 1 ;;
+    [Yy]*) return 0 ;;
+    [Nn]*) return 1 ;;
     esac
   done
 }
@@ -59,15 +60,15 @@ ${warning}If this is an issue, please report it on Github.${reset}
 # Returns the executable for given string, supports aliases.
 function get-exec {
   local cmd="$1"
-  if ! declare -p BASH_ALIASES > /dev/null; then
+  if ! declare -p BASH_ALIASES >/dev/null; then
     declare -A BASH_ALIASES=()
   fi
   local cmd_alias="${BASH_ALIASES[$1]-}"
-  local cmd_which="$(which $cmd 2> /dev/null)"
+  local cmd_which="$(which $cmd 2>/dev/null)"
   local cmd_which_status="$?"
   if [[ "$cmd_alias" != "" ]]; then
     echo "$cmd_alias"
-  elif [[ "$cmd_which_status" == "0" ]] && [[ "$cmd_which" != ""  ]]; then
+  elif [[ "$cmd_which_status" == "0" ]] && [[ "$cmd_which" != "" ]]; then
     echo "$cmd_which"
   else
     return 1
@@ -134,7 +135,7 @@ for package in "${required_packages[@]}"; do
   elif [[ "$bin" == "infozip" ]]; then
     bin="unzip"
   fi
-  if ! get-exec "$bin" > /dev/null; then
+  if ! get-exec "$bin" >/dev/null; then
     echo "$bin is not installed, run ${bold}sudo $pm_install $package${reset} to install."
     exit 1
   fi
@@ -204,8 +205,8 @@ function ac-path-prompt {
   echo "Enter path to ${bold}steamapps/common/assettocorsa${reset}:"
   while :; do
     read -ei "$PWD/" path &&
-    # Converting '~/directory/' to '/home/user/directory'
-    local path="$(echo "${path%"/"}" | sed "s|\~\/|$HOME\/|g")"
+      # Converting '~/directory/' to '/home/user/directory'
+      local path="$(echo "${path%"/"}" | sed "s|\~\/|$HOME\/|g")"
     if [[ -d "$path" ]] && [[ $(basename "$path") == "assettocorsa" ]]; then
       AC_COMMON="$path"
       break
@@ -243,17 +244,18 @@ fi
 # Setting paths dependent on path to Assetto Corsa
 STEAMAPPS="${AC_COMMON%"/common/assettocorsa"}"
 AC_COMPATDATA="$STEAMAPPS/compatdata/244210"
+SIMHUB_DIR="$AC_COMPATDATA/pfx/drive_c/Program Files (x86)/SimHub"
 
 # Checking for potential disk issues
 function check-disk {
-  local dev_path="$(findmnt -no SOURCE --target  "$AC_COMPATDATA")"
+  local dev_path="$(findmnt -no SOURCE --target "$AC_COMPATDATA")"
   local filesystem_type="$(lsblk -no fstype "$dev_path")"
   if [[ "$filesystem_type" == "ntfs" ]]; then
     echo "${warning}Assetto Corsa is installed on a NTFS partition. This will cause issues.${reset}"
   fi
   local available_space=($(df -P "$AC_COMPATDATA" | tail -1))
   available_space="${available_space[3]}"
-  if (( available_space < 1000000 )); then
+  if ((available_space < 1000000)); then
     echo "${warning}The disk that Assetto Corsa is installed on has less than 1GB of free space.${reset}"
   fi
 }
@@ -370,7 +372,7 @@ function delete-wineprefix {
     copied+=1
   fi
   # Deleting the saved configs
-  if [[ -d "ac_configs/" ]] && (( $copied == 2 )); then
+  if [[ -d "ac_configs/" ]] && (($copied == 2)); then
     subprocess rm -r "ac_configs/"
   fi
   # Deleting Content Manager
@@ -429,7 +431,7 @@ function install-content-manager {
     # Adding acmanager to mimeapps.list
     echo "Adding ability to open acmanager links..."
     subprocess sed "s|steam steam://rungameid/244210|$APPLAUNCH_AC|g" -i "$AC_DESKTOP"
-    subprocess gio mime x-scheme-handler/acmanager "Assetto Corsa.desktop" 1>& /dev/null
+    subprocess gio mime x-scheme-handler/acmanager "Assetto Corsa.desktop" 1>&/dev/null
     echo "Opening ${bold}acmanager://${reset} links will only work if Content Manager/Assetto Corsa is not open already."
   else
     echo "Assetto Corsa does not have a .desktop shortcut, URI links to CM will not work."
@@ -507,6 +509,166 @@ function install-dxvk {
   subprocess protontricks --no-background-wineserver 244210 dxvk
 }
 
+function check-simhub {
+  if [[ -d "$SIMHUB_DIR" ]]; then
+    local string="Reinstall SimHub $SIMHUB_VERSION?"
+  else
+    local string="Install SimHub $SIMHUB_VERSION?"
+  fi
+  if ask "$string"; then
+    install-simhub
+  fi
+}
+function install-simhub {
+  echo "Downloading SimHub..."
+  subprocess wget -q "https://github.com/SHWotever/SimHub/releases/download/$SIMHUB_VERSION/SimHub.$SIMHUB_VERSION.zip" -P "temp/"
+  echo "Installing SimHub..."
+  subprocess unzip -qo "temp/SimHub.$SIMHUB_VERSION.zip" -d "temp/"
+  local installer="$(ls temp/SimHubSetup_*.exe | head -1)"
+  subprocess protontricks-launch --appid 244210 "$(pwd)/$installer" /VERYSILENT /SUPPRESSMSGBOXES /DIR="C:\\Program Files (x86)\\SimHub"
+  subprocess rm -rf "temp/"
+  echo "Installing .NET Framework 4.8 (required by SimHub)..."
+  subprocess protontricks 244210 dotnet48
+  echo "Creating launcher script..."
+  subprocess mkdir -p "$HOME/.local/bin"
+  local launcher="$HOME/.local/bin/simhub"
+  cat >"$launcher" <<LAUNCHEREOF
+#! /usr/bin/env bash
+exec protontricks-launch --appid 244210 "$SIMHUB_DIR/SimHubWPF.exe" "\$@"
+LAUNCHEREOF
+  subprocess chmod +x "$launcher"
+  if [[ ":$PATH:" != *":$HOME/.local/bin:"* ]]; then
+    echo "${warning}$HOME/.local/bin is not in PATH. Add it or run SimHub with: ${bold}$launcher${reset}"
+  fi
+  echo "${bold}Start Assetto Corsa from Steam/Content Manager first, then start SimHub with: ${launcher}${reset}"
+}
+
+function get-zip-entry {
+  local zip_file="$1"
+  local filename="$2"
+  local entry
+  while IFS= read -r entry; do
+    if [[ "$entry" == "$filename" ]] || [[ "$entry" == */"$filename" ]]; then
+      echo "$entry"
+      return 0
+    fi
+  done < <(unzip -Z -1 "$zip_file")
+  return 1
+}
+
+function unzip-allow-backslash-warning {
+  local output
+  output="$(unzip "$@" 2>&1)"
+  local status=$?
+  if [[ "$status" == "0" ]]; then
+    return 0
+  fi
+  if [[ "$status" == "1" ]] && [[ "$output" == *"appears to use backslashes as path separators"* ]]; then
+    return 0
+  fi
+  line=($(caller))
+  echo "
+${error}Encountered an error while running 'unzip $@' at line $line:${reset}
+$output
+
+${warning}If this is an issue, please report it on Github.${reset}
+"
+  exit 1
+}
+
+function check-carplay-addon {
+  if [[ ! -d "$SIMHUB_DIR" ]]; then
+    return 1
+  fi
+  if ask "Install Apple CarPlay SimHub dashboard addon?"; then
+    install-carplay-addon
+  fi
+}
+function install-carplay-addon {
+  local default_dir="$HOME/Downloads/Assetto Downloads/Carplay"
+  echo "Enter path to folder containing ${bold}Apple-CarPlay.zip${reset} and ${bold}SimHubUDPConnector.zip${reset}:"
+  read -ei "$default_dir" addon_dir || return 1
+  addon_dir="$(echo "${addon_dir%"/"}" | sed "s|\~\/|$HOME\/|g")"
+
+  local carplay_zip="$addon_dir/Apple-CarPlay.zip"
+  local udpconnector_zip="$addon_dir/SimHubUDPConnector.zip"
+  if [[ ! -f "$carplay_zip" ]] || [[ ! -f "$udpconnector_zip" ]]; then
+    echo "${warning}Apple CarPlay addon install skipped.${reset}"
+    echo "Required files:"
+    echo " - $carplay_zip"
+    echo " - $udpconnector_zip"
+    return 1
+  fi
+
+  local simhubdash_entry
+  simhubdash_entry="$(get-zip-entry "$carplay_zip" "Apple-CarPlay.simhubdash")" || {
+    echo "${error}Apple-CarPlay.simhubdash was not found in $carplay_zip.${reset}"
+    return 1
+  }
+  local dll_entry
+  dll_entry="$(get-zip-entry "$udpconnector_zip" "DaZD.UDPConnector.dll")" || {
+    echo "${error}DaZD.UDPConnector.dll was not found in $udpconnector_zip.${reset}"
+    return 1
+  }
+  local ac_app_entry
+  ac_app_entry="$(get-zip-entry "$udpconnector_zip" "SimHubUDPConnector/Assetto Corsa/app/SimHubUDPConnector.zip")" || {
+    echo "${error}Assetto Corsa SimHubUDPConnector app zip was not found in $udpconnector_zip.${reset}"
+    return 1
+  }
+  local torque_extension_entry
+  torque_extension_entry="$(get-zip-entry "$carplay_zip" "TorquePowerExtensionMy.lua")" || {
+    echo "${error}TorquePowerExtensionMy.lua was not found in $carplay_zip.${reset}"
+    return 1
+  }
+  local font_entry
+  font_entry="$(get-zip-entry "$carplay_zip" "SF-Pro.ttf")" || {
+    echo "${error}SF-Pro.ttf was not found in $carplay_zip.${reset}"
+    return 1
+  }
+
+  local cm_presets_dir="$AC_COMPATDATA/pfx/drive_c/users/steamuser/AppData/Local/AcTools Content Manager/Presets/Custom Previews"
+  local cm_preset_entries=()
+  if [[ -d "$AC_COMPATDATA/pfx/drive_c/users/steamuser/AppData/Local/AcTools Content Manager" ]]; then
+    for preset in "preview_light.cmpreset" "preview_nolight.cmpreset"; do
+      local preset_entry
+      preset_entry="$(get-zip-entry "$carplay_zip" "$preset")" || {
+        echo "${error}$preset was not found in $carplay_zip.${reset}"
+        return 1
+      }
+      cm_preset_entries+=("$preset_entry")
+    done
+  fi
+
+  echo "Installing Apple CarPlay SimHub dashboard addon..."
+  subprocess mkdir -p "temp/carplay"
+  subprocess unzip -qo "$carplay_zip" "$simhubdash_entry" -d "temp/carplay"
+  subprocess mkdir -p "$SIMHUB_DIR/DashTemplates"
+  unzip-allow-backslash-warning -qo "temp/carplay/$simhubdash_entry" -d "$SIMHUB_DIR/DashTemplates"
+  subprocess unzip -jqo "$udpconnector_zip" "$dll_entry" -d "$SIMHUB_DIR"
+  subprocess unzip -jqo "$udpconnector_zip" "$ac_app_entry" -d "temp/carplay"
+  subprocess unzip -qo "temp/carplay/SimHubUDPConnector.zip" -d "$AC_COMMON"
+
+  local extension_dir="$AC_COMMON/apps/lua/SimHubUDPConnector/extensions"
+  subprocess mkdir -p "$extension_dir"
+  subprocess unzip -jqo "$carplay_zip" "$torque_extension_entry" -d "$extension_dir"
+  subprocess mkdir -p "$SIMHUB_DIR/DashFonts" "$AC_COMPATDATA/pfx/drive_c/windows/Fonts"
+  subprocess unzip -jqo "$carplay_zip" "$font_entry" -d "$SIMHUB_DIR/DashFonts"
+  subprocess unzip -jqo "$carplay_zip" "$font_entry" -d "$AC_COMPATDATA/pfx/drive_c/windows/Fonts"
+  if ((${#cm_preset_entries[@]} > 0)); then
+    subprocess mkdir -p "$cm_presets_dir"
+    for preset_entry in "${cm_preset_entries[@]}"; do
+      subprocess unzip -jqo "$carplay_zip" "$preset_entry" -d "$cm_presets_dir"
+    done
+  fi
+
+  subprocess rm -rf "temp/"
+  echo "${bold}Apple CarPlay addon installed. Post-install steps:
+ 1. Start Assetto Corsa first, then SimHub.
+ 2. In AC/CSP, enable the SimHub UDPConnector extension and activate TorquePowerExtensionMy.
+ 3. In SimHub, enable Media Information and set the dashboard's simulated keys to match AC controls.
+ 4. In Content Manager, generate previews twice using preview_light and preview_nolight.${reset}"
+}
+
 function check-generated-files {
   if [ ! -d "$AC_COMPATDATA/pfx/drive_c/Program Files (x86)/Steam/config" ]; then
     echo "\
@@ -530,6 +692,8 @@ OPTIONAL_STEPS=(
   check-csp
   check-csp-config
   check-dxvk
+  check-simhub
+  check-carplay-addon
 )
 echo
 for func in "${OPTIONAL_STEPS[@]}"; do

--- a/assettocorsa-linux-setup.sh
+++ b/assettocorsa-linux-setup.sh
@@ -184,10 +184,8 @@ fi
 
 if [[ "$STEAM_INSTALL" == "native" ]]; then
   STEAM_DIR="$NATIVE_STEAM_DIR"
-  APPLAUNCH_AC="steam -applaunch 244210 %u"
 elif [[ "$STEAM_INSTALL" == "flatpak" ]]; then
   STEAM_DIR="$FLATPAK_STEAM_DIR"
-  APPLAUNCH_AC="flatpak run com.valvesoftware.Steam -applaunch 244210 %u"
 else
   echo "Invalid STEAM_INSTALL '$STEAM_INSTALL'"
   exit 1
@@ -197,8 +195,6 @@ fi
 AC_COMMON="$STEAM_DIR/steamapps/common/assettocorsa"
 COMPAT_TOOLS_DIR="$STEAM_DIR/compatibilitytools.d"
 STEAM_LIBRARY_VDF="$STEAM_DIR/steamapps/libraryfolders.vdf"
-# Setting universal paths
-AC_DESKTOP="$HOME/.local/share/applications/Assetto Corsa.desktop"
 
 # Getting path to Assetto Corsa
 function ac-path-prompt {
@@ -395,6 +391,65 @@ function check-content-manager {
     install-content-manager
   fi
 }
+function install-acmanager-handler {
+  local handler="$HOME/.local/bin/acmanager-handler"
+  local desktop_file="$HOME/.local/share/applications/acmanager-handler.desktop"
+  local mimelist="$HOME/.config/mimeapps.list"
+  local ac_exe="$AC_COMMON/AssettoCorsa.exe"
+  local quoted_ac_exe
+  printf -v quoted_ac_exe "%q" "$ac_exe"
+
+  echo "Adding ability to open acmanager links..."
+  subprocess mkdir -p "$HOME/.local/bin" "$HOME/.local/share/applications"
+  cat >"$handler" <<HANDLEREOF
+#! /usr/bin/env bash
+set -u
+
+uri="\${1-}"
+if [[ "\$uri" == "" ]]; then
+  exit 0
+fi
+
+ac_exe=$quoted_ac_exe
+if pgrep "AssettoCorsa.ex" >/dev/null; then
+  exec protontricks-launch --appid 244210 "\$ac_exe" "\$uri"
+fi
+
+HANDLEREOF
+
+  if [[ "$STEAM_INSTALL" == "native" ]]; then
+    cat >>"$handler" <<'HANDLEREOF'
+exec steam -applaunch 244210 "$uri"
+HANDLEREOF
+  elif [[ "$STEAM_INSTALL" == "flatpak" ]]; then
+    cat >>"$handler" <<'HANDLEREOF'
+exec flatpak run com.valvesoftware.Steam -applaunch 244210 "$uri"
+HANDLEREOF
+  else
+    echo "${error}Invalid STEAM_INSTALL '$STEAM_INSTALL'${reset}"
+    exit 1
+  fi
+
+  subprocess chmod +x "$handler"
+  cat >"$desktop_file" <<DESKTOPEOF
+[Desktop Entry]
+Type=Application
+Name=Content Manager URI Handler
+Exec="$handler" %u
+MimeType=x-scheme-handler/acmanager;
+NoDisplay=true
+DESKTOPEOF
+
+  # Cleaning up previous modifications to mimeapps.list
+  if [[ -f "$mimelist" ]]; then
+    subprocess sed "s|x-scheme-handler/acmanager=Assetto Corsa.desktop;||g" -i "$mimelist"
+    subprocess sed "s|x-scheme-handler/acmanager=Assetto Corsa.desktop||g" -i "$mimelist"
+    subprocess sed '$!N; /^\(.*\)\n\1$/!P; D' -i "$mimelist"
+  fi
+
+  subprocess gio mime x-scheme-handler/acmanager "acmanager-handler.desktop" 1>/dev/null
+  echo "Opening ${bold}acmanager://${reset} links will try to pass race invites to Content Manager, even when it is already open."
+}
 function install-content-manager {
   # Installing cm
   echo "Installing Content Manager..."
@@ -419,23 +474,7 @@ function install-content-manager {
   local link_from="$STEAM_DIR/config/loginusers.vdf"
   local link_to="$AC_COMPATDATA/pfx/drive_c/Program Files (x86)/Steam/config/loginusers.vdf"
   subprocess ln -sf "$link_from" "$link_to"
-  # Adding ability to open acmanager uri links
-  if [[ -f "$AC_DESKTOP" ]]; then
-    mimelist="$HOME/.config/mimeapps.list"
-    # Cleaning up previous modifications to mimeapps.list
-    if [[ -f "$mimelist" ]]; then
-      subprocess sed "s|x-scheme-handler/acmanager=Assetto Corsa.desktop;||g" -i "$mimelist"
-      subprocess sed "s|x-scheme-handler/acmanager=Assetto Corsa.desktop||g" -i "$mimelist"
-      subprocess sed '$!N; /^\(.*\)\n\1$/!P; D' -i "$mimelist"
-    fi
-    # Adding acmanager to mimeapps.list
-    echo "Adding ability to open acmanager links..."
-    subprocess sed "s|steam steam://rungameid/244210|$APPLAUNCH_AC|g" -i "$AC_DESKTOP"
-    subprocess gio mime x-scheme-handler/acmanager "Assetto Corsa.desktop" 1>&/dev/null
-    echo "Opening ${bold}acmanager://${reset} links will only work if Content Manager/Assetto Corsa is not open already."
-  else
-    echo "Assetto Corsa does not have a .desktop shortcut, URI links to CM will not work."
-  fi
+  install-acmanager-handler
   echo "When starting Content Manager, set the root Assetto Corsa folder to ${bold}Z:$AC_COMMON${reset}"
 }
 # Checking if CSP is installed


### PR DESCRIPTION
## Summary

Adds optional SimHub and Apple CarPlay addon support, and improves Content Manager race invite handling for `acmanager://` links.

## What changed

- Adds an optional SimHub `9.11.13` install step into Assetto Corsa’s Proton prefix.
- Installs SimHub dependencies, including `.NET Framework 4.8`.
- Creates a local SimHub launcher at `~/.local/bin/simhub`.
- Adds an optional Apple CarPlay addon installer when SimHub is present.
- Installs the CarPlay dashboard, SimHub UDP connector plugin, Assetto Corsa UDP connector app, torque extension, required font, and
  Content Manager preview presets when available.
- Adds a dedicated `acmanager://` URI handler for Content Manager race invite links.
- Supports race invite links when Content Manager is closed by launching through Steam.
- Attempts to pass race invite links directly into the existing Proton prefix when Content Manager is already running.
- Updates the README with SimHub, CarPlay, and race invite guidance.

## Notes

SimHub should be started after launching Assetto Corsa through Steam or Content Manager. Launching Assetto Corsa from SimHub can prevent Steam from starting the game correctly.

The CarPlay addon installer expects these files in the selected folder:

- `Apple-CarPlay.zip`
- `SimHubUDPConnector.zip`

If a race invite source still fails, users can copy the `ip` and `httpPort` values from the link and search for `ip:httpPort` in Content Manager’s server browser